### PR TITLE
remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,7 +743,6 @@ ExecStart=/usr/local/bin/kube-apiserver \\
   --service-account-key-file=/var/lib/kubernetes/ca-key.pem \\
   --service-cluster-ip-range=10.32.0.0/24 \\
   --service-node-port-range=30000-32767 \\
-  --tls-ca-file=/var/lib/kubernetes/ca.pem \\
   --tls-cert-file=/var/lib/kubernetes/kubernetes.pem \\
   --tls-private-key-file=/var/lib/kubernetes/kubernetes-key.pem \\
   --v=2


### PR DESCRIPTION
remove the flag --tls-ca-file as it is been removed from the CLI of kube apiserver. For reference, this flag is missing [here](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/)